### PR TITLE
Vol mount fix

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.2
+version: 1.1.4

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -40,12 +40,6 @@
 {{- define "omar-basemap.volumeMounts" -}}
 {{- include "omar-basemap.volumeMounts.configmaps" . -}}
 {{- include "omar-basemap.volumeMounts.pvcs" . -}}
-{{- if .Values.global.extraVolumeMounts }}
-{{ toYaml .Values.global.extraVolumeMounts }}
-{{- end }}
-{{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts }}
-{{- end }}
 {{- end -}}
 
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -78,10 +78,6 @@ ossimDataLocalMountPath: /data
 
 configmaps: {}
 
-extraVolumes: []
-
-extraVolumeMounts: []
-
 extraInitContainers: []
 
 sideCars: []


### PR DESCRIPTION
The jump from 1.1.2 to 1.1.4 has the correct fix. 1.2.3 did not have the function removed from the _helpers.tpl file